### PR TITLE
Lock rspec to 2.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem "fakefs"
   gem "jruby-openssl", :platform => :jruby
   gem "json"
-  gem "rspec", ">= 2.0"
+  gem "rspec", "2.13.0"
   gem "sqlite3"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbot (0.1.33)
+    turbot (0.1.34)
       activesupport (= 4.1.4)
       excon
       launchy (>= 0.3.2)
@@ -10,7 +10,7 @@ PATH
       rubyzip (>= 1.0.0)
       turbot-api (= 0.0.14)
       turbot-runner (= 0.2.3)
-      turbotlib (~> 0.0.8)
+      turbotlib (~> 0.0.9)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +50,7 @@ GEM
       clamp (~> 0.6)
       ffi
       json (>= 1.7.7)
-    httpclient (2.6.0.1)
+    httpclient (2.7.0.1)
     i18n (0.7.0)
     json (1.8.1)
     json-schema-openc-fork (0.0.1)
@@ -59,7 +59,7 @@ GEM
       addressable (~> 2.3)
     method_source (0.8.2)
     mime-types (1.25.1)
-    minitest (5.8.0)
+    minitest (5.8.2)
     netrc (0.7.9)
     openc-json_schema (0.0.13)
       json-schema-openc-fork (= 0.0.1)
@@ -76,18 +76,14 @@ GEM
     rest-client (1.6.9)
       mime-types (~> 1.16)
     rr (1.0.5)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
     scraperwiki (3.0.2)
@@ -105,7 +101,7 @@ GEM
     turbot-runner (0.2.3)
       activesupport (= 4.1.4)
       openc-json_schema (= 0.0.13)
-    turbotlib (0.0.8)
+    turbotlib (0.0.9)
       scraperwiki (= 3.0.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -129,7 +125,10 @@ DEPENDENCIES
   pry
   rake (>= 0.8.7)
   rr (~> 1.0.2)
-  rspec (>= 2.0)
+  rspec (= 2.13.0)
   sqlite3
   turbot!
   webmock
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
```
2.14.0 deprecates mock and stub!
>= 3 errors with "undefined method `color_enabled='"
```

Otherwise, can't run specs.