### PR TITLE
Use Bundler's rake release task instead of custom ./publish.sh script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,40 +1,16 @@
-# For Bundler.with_clean_env
-require 'bundler/setup'
-
-require 'open-uri'
-
-require 'rss'
-require 'turbot'
-
-desc "Make a release"
-task :release do
-  version = Turbot::VERSION
-  rubygems_versions = []
-  open('http://rubygems.org/gems/turbot/versions.atom') do |rss|
-    feed = RSS::Parser.parse(rss, false)
-    rubygems_versions = feed.items.map do |i|
-      i.id.content.split("/").last
-    end
-  end
-  if rubygems_versions.include? version
-    puts "Latest version already published; quitting"
-    exit 0
-  else
-    begin
-      puts "Building gem..."
-      system("gem build turbot.gemspec")
-      puts "Pushing gem..."
-      system("gem push $(ls *gem|tail -1)")
-    ensure
-      system("rm *gem")
-    end
-    puts "Writing new version on turbot server"
-    system(%Q{ssh turbot1 "echo #{version} > /home/openc/sites/turbot_server/current/public/version.txt"})
-    puts "Now chance the build_version in omnibus-turbot-client/turbot-client.rb and build the new targets"
-  end
-end
+require 'bundler'
+Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+begin
+  require 'yard'
+  YARD::Rake::YardocTask.new
+rescue LoadError
+  task :yard do
+    abort 'YARD is not available. In order to run yard, you must: gem install yard'
+  end
+end

--- a/publish.sh
+++ b/publish.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-gem build turbot.gemspec
-gem push $(ls *gem|tail -1)
-
-function clean {
- rm *gem
-}
-trap clean EXIT


### PR DESCRIPTION
Note that there was an old `release` task with the lines:

```ruby
system(%Q{ssh turbot1 "echo #{version} > /home/openc/sites/turbot_server/current/public/version.txt"})
puts "Now chance the build_version in omnibus-turbot-client/turbot-client.rb and build the new targets"
```

I don't know if this task is still being used, as `publish.sh` doesn't include the above (both are being removed in favor of Bundler's `rake release` task). The OC wiki doesn't mention `version.txt` or `build_version`.

The [`build_version`](https://github.com/openc/omnibus-turbot-client/blob/87da9ec8159f367c9946c59103a1da61a0a28c26/config/projects/turbot-client.rb#L6) in `omnibus-turbot-client` hasn't been changed in ages.