### PR TITLE
auth:whoami and auth:token error with "not logged in" if not logged in

### DIFF
--- a/lib/turbot/command/auth.rb
+++ b/lib/turbot/command/auth.rb
@@ -64,7 +64,12 @@ class Turbot::Command::Auth < Turbot::Command::Base
   def token
     validate_arguments!
 
-    display Turbot::Auth.api_key
+    api_key = Turbot::Auth.api_key
+    if api_key
+      display api_key
+    else
+      error "not logged in"
+    end
   end
 
   # auth:whoami
@@ -79,7 +84,12 @@ class Turbot::Command::Auth < Turbot::Command::Base
   def whoami
     validate_arguments!
 
-    display Turbot::Auth.user
+    user = Turbot::Auth.user(false)
+    if user.empty?
+      error "not logged in"
+    else
+      display user
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,9 +64,6 @@ def execute(command_line)
     stub(base).bot.returns("example")
   end
 
-  stub(Turbot::Auth).get_credentials.returns(['email@example.com', 'apikey01'])
-  stub(Turbot::Auth).api_key.returns('apikey01')
-
   original_stdin, original_stderr, original_stdout = $stdin, $stderr, $stdout
 
   $stdin  = captured_stdin  = StringIO.new
@@ -129,19 +126,6 @@ end
 
 def fail_command(message)
   raise_error(Turbot::Command::CommandFailed, message)
-end
-
-def stub_core
-  @stubbed_core ||= begin
-    stubbed_core = nil
-    any_instance_of(Turbot::Client) do |core|
-      stubbed_core = stub(core)
-    end
-    stub(Turbot::Auth).user.returns("email@example.com")
-    stub(Turbot::Auth).password.returns("pass")
-    stub(Turbot::Client).auth.returns("apikey01")
-    stubbed_core
-  end
 end
 
 def stub_pg

--- a/spec/turbot/command/auth_spec.rb
+++ b/spec/turbot/command/auth_spec.rb
@@ -16,6 +16,18 @@ describe Turbot::Command::Auth do
   describe "auth:token" do
 
     it "displays the user's api key" do
+      Turbot::Auth.stub(:api_key).and_return('apikey01')
+
+      stderr, stdout = execute("auth:token")
+      stderr.should == ""
+      stdout.should == <<-STDOUT
+apikey01
+STDOUT
+    end
+
+    it "displays the user's api key" do
+      Turbot::Auth.stub(:api_key).and_return(nil)
+
       stderr, stdout = execute("auth:token")
       stderr.should == ""
       stdout.should == <<-STDOUT
@@ -26,11 +38,23 @@ STDOUT
 
   describe "auth:whoami" do
     it "displays the user's email address" do
+      Turbot::Auth.stub(:read_credentials).and_return(['email@example.com', 'apikey01'])
+
       stderr, stdout = execute("auth:whoami")
       stderr.should == ""
       stdout.should == <<-STDOUT
 email@example.com
 STDOUT
+    end
+
+    it "displays a message if not logged in" do
+      Turbot::Auth.stub(:read_credentials).and_return(false)
+
+      stderr, stdout = execute("auth:whoami")
+      stdout.should == ""
+      stderr.should == <<-STDERR
+ !    not logged in
+STDERR
     end
 
   end

--- a/spec/turbot/command/bots_spec.rb
+++ b/spec/turbot/command/bots_spec.rb
@@ -58,6 +58,9 @@ puts JSON.dump(#{hash})
 
     describe "#info" do
       it "should succeed" do
+        Turbot::Auth.stub(:read_credentials).and_return(['email@example.com', 'apikey01'])
+        Turbot::Auth.stub(:api_key).and_return('apikey01')
+
         stub_api_request(:get, "/api/bots/example?api_key=apikey01").to_return({
           :body => json_encode({
             "data" => {

--- a/spec/turbot/command_spec.rb
+++ b/spec/turbot/command_spec.rb
@@ -19,7 +19,6 @@ end
 describe Turbot::Command do
   before {
     Turbot::Command.load
-    stub_core # setup fake auth
   }
 
   describe "parsing errors" do


### PR DESCRIPTION
Tests are failing because stubs don't override each other. Also, `unstub` seems to have no effect at the class level. Upgrading Rspec may resolve the issue (Rspec 3 uses saner stubbing). Otherwise, see #42.

Closes #28.