### PR TITLE
Eliminate default --format documentation --backtrace rspec arguments

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---backtrace
---format documentation


### PR DESCRIPTION
These just make the output incredibly long. I only want `--backtrace` some of the time, and I can turn it on easily. I never want `--format documentation`.